### PR TITLE
Osuse group

### DIFF
--- a/macros.ghc-extra
+++ b/macros.ghc-extra
@@ -40,8 +40,10 @@ This package provides the Haskell %{pkgname} library development files.\
 %ghc_pkg_recache\
 \
 %files -n %{basepkg} -f %{basepkg}.files\
+%defattr(-,root,root,-)\
 %{?base_doc_files:%doc %base_doc_files}\
 \
 %files -n %{basepkg}-devel -f %{basepkg}-devel.files\
+%defattr(-,root,root,-)\
 %{?devel_doc_files:%doc %devel_doc_files}\
 %{nil}

--- a/macros.ghc-extra
+++ b/macros.ghc-extra
@@ -9,6 +9,7 @@
 %define basepkg %{ghc_prefix}-%{pkgname}\
 %package -n %{basepkg}\
 Summary:        Haskell %{pkgname} library\
+Group:          System/Libraries\
 %{?1:Version:        %{pkgver}}\
 %{-l:License:        %{-l*}}\
 Url:            http://hackage.haskell.org/package/%{pkgname}\
@@ -19,6 +20,7 @@ This package provides the Haskell %{pkgname} library.\
 \
 %package -n %{basepkg}-devel\
 Summary:        Haskell %{pkgname} library development files\
+Group:          Development/Languages/Other\
 %{?1:Version:        %{pkgver}}\
 %{-l:License:        %{-l*}}\
 Requires(post): %{ghc_prefix}-compiler = %{ghc_version}\


### PR DESCRIPTION
Simplify openSUSE and SUSE packaging by add "Group:" tag to ghc_lib_subpackage macro which is required in openSUSE packaging policy 
https://en.opensuse.org/openSUSE:Package_group_guidelines

and add default atributes in "%file" section as is needed by https://en.opensuse.org/openSUSE:Package_group_guidelines

both changes improves openSUSE compactibility of ghc-rpm-macros ,  + doesn't affect redhat packaging
